### PR TITLE
Fixes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ While the primary use case of the `login` method is to call it without any argum
 
 * *serviceName* - Provide a custom service name that will be included in the User Agent string for tracking.
 
+* *serviceClientId* - Provide a custom Azure AD client ID that will be used when presenting the end-user with the consent screen, during an interactive login. If unspecified, the "Microsoft Cross Platform CLI" identity will be used, which may be confusing.
+
 #### LoginResult
 
 After the authentication process is successfully completed, the `Promise` returned by the `login` method will resolve with an object that includes the following properties:

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ const DEFAULT_INTERACTIVE_LOGIN_HANDLER = (code) => {
 function authenticate({ clientId = env.azureServicePrincipalClientId || env.ARM_CLIENT_ID,
                         clientSecret = env.azureServicePrincipalPassword || env.ARM_CLIENT_SECRET,
                         tenantId = env.azureServicePrincipalTenantId || env.ARM_TENANT_ID,
-                        interactiveLoginHandler = DEFAULT_INTERACTIVE_LOGIN_HANDLER }) {
+                        interactiveLoginHandler = DEFAULT_INTERACTIVE_LOGIN_HANDLER,
+                        serviceClientId }) {
     return new Promise((resolve, reject) => {
         let interactive = false;
 
@@ -79,7 +80,7 @@ function authenticate({ clientId = env.azureServicePrincipalClientId || env.ARM_
                 require("opn")(INTERACTIVE_LOGIN_URL, { wait: false });
             };
 
-            azure.interactiveLogin({ userCodeResponseLogger }, resolvePromise);
+            azure.interactiveLogin({ clientId: serviceClientId, userCodeResponseLogger }, resolvePromise);
         }
     });
 }
@@ -209,9 +210,9 @@ function resolveSubscription(subscriptions, subscriptionId = env.azureSubId || e
     }
 }
 
-exports.login = ({ clientId, clientSecret, tenantId, subscriptionId, interactiveLoginHandler, subscriptionResolver, serviceName } = {}) => {
+exports.login = ({ clientId, clientSecret, tenantId, subscriptionId, interactiveLoginHandler, subscriptionResolver, serviceName, serviceClientId } = {}) => {
     let state;
-    return authenticate({ clientId, clientSecret, tenantId, interactiveLoginHandler }).then(({ credentials, interactive, subscriptions }) => {
+    return authenticate({ clientId, clientSecret, tenantId, serviceClientId, interactiveLoginHandler }).then(({ credentials, interactive, subscriptions }) => {
         const accessToken = credentials.tokenCache._entries[0].accessToken;
 
         state = {


### PR DESCRIPTION
This change simply allows "services" (e.g. things that consume `az-login` ala Serverless, Az.js, VS Code extensions) to specify a custom ADAL clientID, so that the interactive login process displays the appropriate display name when asking end-users for consent, as opposed to statically displaying "Microsoft XPlat CLI".