### PR TITLE
Add MSA support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
             "program": "${workspaceRoot}/examples/index.js",
             "protocol": "inspector",
             "env": {
-                "azureServicePrincipalClientId": ""
+                "azureServicePrincipalClientId": "",
+                "azureSubId": ""
             }
         }
     ]

--- a/examples/index.js
+++ b/examples/index.js
@@ -16,4 +16,8 @@ login().then(({ clientFactory }) => {
         const prettyGroups = util.inspect(groups, { colors: true });
         console.log(prettyGroups);
     });
+}).catch((error) => {
+    // Optionally, catch any errors that occur
+    // as a part of the login process.
+    console.log(error);
 });


### PR DESCRIPTION
This addresses #9 by adding support for logging in with a Microsoft Account, as opposed to just Azure AD accounts.

Additionally, while I was testing this fix, I realized that the `login` method didn't reject disabled subscriptions appropriately, so I added that support in as well. Otherwise, you could end up in a wierd situation where you successfully login, but then can't actually manage the Azure account due to the subscription being disabled. This new approach ensures that you "fail fast", in a way that is much more intuitive.